### PR TITLE
ci: update AI reviewer — add PR summarization + 'ai summarize' trigger

### DIFF
--- a/.github/workflows/ai-code-reviewer.yml
+++ b/.github/workflows/ai-code-reviewer.yml
@@ -1,17 +1,36 @@
-# AI Code Review — powered by GitHub Models (gpt-4o) via GITHUB_TOKEN.
-# No API keys or secrets required.
-name: AI PR Code Review
+# AI PR Analysis — powered by GitHub Models (gpt-4o) via GITHUB_TOKEN.
+# Drop this file into .github/workflows/ of any repository to enable:
+#   1. Commit-by-commit PR summary (ported from Summarize-Pull-Request)
+#   2. Per-file code review with inline diff comments
+#   3. Magic re-trigger: comment "ai summarize" on a PR to re-run analysis
+#
+# Prerequisites: GitHub Copilot subscription. No secrets needed.
+name: AI PR Analysis
 
 on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+  issue_comment:
+    types: [created]
+
 jobs:
-  ai-review:
+  ai-analysis:
+    # Skip non-PR issue comments and bot-authored comments
+    if: >
+      github.event_name == 'pull_request' ||
+      (
+        github.event.issue.pull_request != null &&
+        !github.event.comment.performed_via_github_app &&
+        contains(github.event.comment.body, 'ai summarize')
+      )
     uses: nidhinsai/ai-code-reviewer/.github/workflows/pr-review.yml@main
     with:
-      pr_number: ${{ github.event.pull_request.number }}
-      repository: ${{ github.repository }}
+      pr_number:    ${{ github.event.pull_request.number || 0 }}
+      repository:   ${{ github.repository }}
+      event_name:   ${{ github.event_name }}
+      comment_body: ${{ github.event.comment.body || '' }}
+      issue_number: ${{ github.event.issue.number || 0 }}
     permissions:
       pull-requests: write
       contents: read


### PR DESCRIPTION
## Update: AI PR Analysis (v2)

Updates the AI reviewer workflow to use the new combined agent that includes:

1. **Commit-by-commit PR summary** — each commit diff is sent to gpt-4o to summarise key changes and potential problems. If >1 commit, a second LLM pass creates an overall synthesis.
2. **Per-file code review** — unchanged, rates each file with inline comments
3. **Magic trigger**: comment **`ai summarize`** on any PR to re-run the full analysis

_Replaces `nidhinsai/Summarize-Pull-Request` which has been deleted._